### PR TITLE
Experiment with Handlers instead of Actions

### DIFF
--- a/src/main/scala/com/lightbend/lagom/core/persistence/effects/core/persistence/AccountEntity.scala
+++ b/src/main/scala/com/lightbend/lagom/core/persistence/effects/core/persistence/AccountEntity.scala
@@ -37,7 +37,7 @@ class AccountEntity extends PersistentEntity[AccountCommand[_], AccountEvent, Ac
 
 
   // on creation and later
-  val depositCommandHandlers =
+  val depositCommandHandlers: CommandHandlers =
     onCommand {
       // this is directive builder that expects one single Event
       Handler[Deposit]
@@ -51,7 +51,7 @@ class AccountEntity extends PersistentEntity[AccountCommand[_], AccountEvent, Ac
         .replyWith(_.amount)
     }
 
-  def withdrawCommandHandlers(account: Account) =
+  def withdrawCommandHandlers(account: Account): CommandHandlers =
     onCommand {
       Handler[Withdraw]
         .attempt.persistOne { // <- this Effect builder expects a Try[Event]
@@ -68,7 +68,7 @@ class AccountEntity extends PersistentEntity[AccountCommand[_], AccountEvent, Ac
     * behind the scenes, this is a regular Effect with a NoOps command handler.
     * It doesn't have callbacks neither, but do have a reply.
     */
-  val readOnlyCommandHandlers =
+  val readOnlyCommandHandlers: CommandHandlers =
     onCommand {
       ReadOnly[GetBalance.type].replyWith(_.amount)
     }
@@ -78,13 +78,13 @@ class AccountEntity extends PersistentEntity[AccountCommand[_], AccountEvent, Ac
       ReadOnly[GetState.type].replyWith(identity)
     }
 
-  val atCreationEventsHandlers =
+  val atCreationEventsHandlers: EventHandlers =
     onEvent {
       // at creation time, first DepositExecuted initialises the account
       case evt: DepositExecuted => Account(evt.amount)
     }
 
-  def afterCreationEventsHandlers(account: Account) =
+  def afterCreationEventsHandlers(account: Account): EventHandlers =
     onEvent {
       case evt: DepositExecuted => account.copy(amount = account.amount + evt.amount)
       case evt: WithdrawExecuted => account.copy(amount = account.amount - evt.amount)

--- a/src/main/scala/com/lightbend/lagom/core/persistence/effects/core/persistence/AccountEntity.scala
+++ b/src/main/scala/com/lightbend/lagom/core/persistence/effects/core/persistence/AccountEntity.scala
@@ -53,8 +53,7 @@ class AccountEntity extends PersistentEntity[AccountCommand[_], AccountEvent, Ac
 
   def withdrawCommandHandlers(account: Account): CommandHandlers =
     onCommand {
-      Handler[Withdraw]
-        .attempt
+      TryHandler[Withdraw]
         .persistOne { // <- this Effect builder expects a Try[Event]
           case cmd =>
             account

--- a/src/main/scala/com/lightbend/lagom/core/persistence/effects/core/persistence/AccountEntity.scala
+++ b/src/main/scala/com/lightbend/lagom/core/persistence/effects/core/persistence/AccountEntity.scala
@@ -8,89 +8,87 @@ import scala.util.{Failure, Success}
 class AccountEntity extends PersistentEntity[AccountCommand[_], AccountEvent, Account] {
 
   /**
-    * Behavior is a PartialFunction from Option[State] => Actions
+    * Behavior is a PartialFunction from Option[State] => Handlers
     *
-    * When there is no state (None) we provide the actions that will build the Entity
+    * When there is no state (None) we provide the handlers that will build the Entity
     * (equivalent to a constructor, but expressed as Command and Event Handlers)
     *
-    * When there is a state (Some[State]) we provide the actions that are able to update the Entity.
+    * When there is a state (Some[State]) we provide the handlers that are able to update the Entity.
     *
-    * In the absence of a snapshot, the Option[State] == None and we read events starting from first offset.
+    * In the absence of a snapshot, Option[State] == None and we replay the events starting from first offset.
     * This basically replays the event that is responsible for creating the model (the seed event).
     */
   override def behavior =
     Behavior
-      .first { // None => Actions == () => Actions
+      .first { // None => Handlers == () => Handlers
         // first we define actions that can construct the Account
         // we go from None => Some[Account]
-        depositCommandActions orElse atCreationEvents
+        depositCommandHandlers and atCreationEventsHandlers
       }
-      .andThen { // Some[State] => Actions == State => Actions
+      .andThen { // Some[State] => Handlers == State => Handlers
         // here come the actions that are valid when Account
         // is already created
         case account =>
-          readOnlyCommands orElse
-            withdrawCommandActions(account) orElse
-            depositCommandActions orElse
-            afterCreationEvents(account)
+          readOnlyCommandHandlers and
+            withdrawCommandHandlers(account) and
+            depositCommandHandlers and
+            afterCreationEventsHandlers(account)
       }
+
 
   // on creation and later
-  val depositCommandActions =
-    actions
-      .onCommand {
-        // this is directive builder that expects one single Event
-        Handler[Deposit]
-          .persistOne {
-            case cmd => DepositExecuted(cmd.amount)
-          }
-          .andThen {  (evt, state) =>
-            println(s"Deposit ${evt.amount}, current balance is ${state.amount}")
-          }
-          // reply with new balance
-          .replyWith(_.amount)
-      }
+  val depositCommandHandlers =
+    onCommand {
+      // this is directive builder that expects one single Event
+      Handler[Deposit]
+        .persistOne {
+          case cmd => DepositExecuted(cmd.amount)
+        }
+        .andThen { (evt, state) =>
+          println(s"Deposit ${evt.amount}, current balance is ${state.amount}")
+        }
+        // reply with new balance
+        .replyWith(_.amount)
+    }
 
-  def withdrawCommandActions(account: Account) =
-    actions
-      .onCommand {
-        Handler[Withdraw]
-          .attempt.persistOne { // <- this Effect builder expects a Try[Event]
-            case cmd if account.amount - cmd.amount >= 0 => Success(WithdrawExecuted(cmd.amount))
-            case cmd => Failure(new RuntimeException("Insufficient balance"))
-          }
-          // NOTE: we don't need reply because Withdraw replies with Done
-          // and there is an implicit for it
+  def withdrawCommandHandlers(account: Account) =
+    onCommand {
+      Handler[Withdraw]
+        .attempt.persistOne { // <- this Effect builder expects a Try[Event]
+        case cmd if account.amount - cmd.amount >= 0 => Success(WithdrawExecuted(cmd.amount))
+        case cmd => Failure(new RuntimeException("Insufficient balance"))
       }
+      // NOTE: we don't need reply because Withdraw replies with Done
+      // and there is an implicit for it
+    }
 
 
-  // read-only commands are no different, it's just an effect without a command handler
-  // behind the scenes, this is a regular Effect with a NoOps command handler.
-  // It doesn't have callbacks neither, but do have a reply.
-  val readOnlyCommands =
-    actions
-      .onCommand {
-        ReadOnly[GetBalance.type].replyWith(_.amount)
-      }
-      .onCommand {
-        // there is also an implicit for reply with State
-        // but intellij gives an error hence the explicit call here
-        ReadOnly[GetState.type].replyWith(identity)
-      }
+  /**
+    * read-only commands are no different, it's just an effect without a command handler
+    * behind the scenes, this is a regular Effect with a NoOps command handler.
+    * It doesn't have callbacks neither, but do have a reply.
+    */
+  val readOnlyCommandHandlers =
+    onCommand {
+      ReadOnly[GetBalance.type].replyWith(_.amount)
+    }
+    .onCommand {
+      // there is also an implicit for reply with State
+      // but intellij gives an error hence the explicit call here
+      ReadOnly[GetState.type].replyWith(identity)
+    }
 
-  val atCreationEvents =
-    actions
-      .onEvent {
-        // at creation time, first DepositExecuted initialises the account
-        case evt: DepositExecuted => Account(evt.amount)
-      }
+  val atCreationEventsHandlers =
+    onEvent {
+      // at creation time, first DepositExecuted initialises the account
+      case evt: DepositExecuted => Account(evt.amount)
+    }
 
-  def afterCreationEvents(account: Account) =
-    actions
-      .onEvent {
-        case evt: DepositExecuted => account.copy(amount = account.amount + evt.amount)
-        case evt: WithdrawExecuted => account.copy(amount = account.amount - evt.amount)
-      }
+  def afterCreationEventsHandlers(account: Account) =
+    onEvent {
+      case evt: DepositExecuted => account.copy(amount = account.amount + evt.amount)
+      case evt: WithdrawExecuted => account.copy(amount = account.amount - evt.amount)
+    }
 
 
 }
@@ -100,9 +98,11 @@ case class Account(amount: Double)
 sealed trait AccountCommand[R] extends ReplyType[R]
 
 case class Deposit(amount: Double) extends AccountCommand[Double]
+
 case class Withdraw(amount: Double) extends AccountCommand[Done]
 
 case object GetBalance extends AccountCommand[Double]
+
 case object GetState extends AccountCommand[Account]
 
 

--- a/src/main/scala/com/lightbend/lagom/core/persistence/effects/core/persistence/PersistentEntity.scala
+++ b/src/main/scala/com/lightbend/lagom/core/persistence/effects/core/persistence/PersistentEntity.scala
@@ -287,22 +287,31 @@ abstract class PersistentEntity[Command <: WithReply, Event, State] {
         case cmd if handler.isDefinedAt(cmd) => Try(handler(cmd))
       }
 
-    object attempt {
-
-      def persistOne(handler: PartialFunction[C, Try[Event]]): EffectBuilderOne[C] =
-        EffectBuilderOne[C](handler)
-
-      def persistAll(handler: PartialFunction[C, Try[immutable.Seq[Event]]]): EffectBuilderAll[C] =
-        EffectBuilderAll[C](handler)
-
-    }
-
-    object optionally {
-      def persistOne(handler: PartialFunction[C, Option[Event]]): EffectBuilderOptionOne[C] =
-        EffectBuilderOptionOne[C](handler)
-    }
-
   }
 
 
+  object TryHandler {
+    def apply[C <: Command : ClassTag]: TryHandlerSyntax[C] =
+      new TryHandlerSyntax[C]
+  }
+
+  class TryHandlerSyntax[C <: WithReply : ClassTag] {
+
+    def persistOne(handler: PartialFunction[C, Try[Event]]): EffectBuilderOne[C] =
+      EffectBuilderOne[C](handler)
+
+    def persistAll(handler: PartialFunction[C, Try[immutable.Seq[Event]]]): EffectBuilderAll[C] =
+      EffectBuilderAll[C](handler)
+  }
+
+  object OptionHandler {
+    def apply[C <: Command : ClassTag]: OptionHandlerSyntax[C] =
+      new OptionHandlerSyntax[C]
+  }
+
+  class OptionHandlerSyntax[C <: WithReply : ClassTag] {
+
+    def persistOne(handler: PartialFunction[C, Option[Event]]): EffectBuilderOptionOne[C] =
+      EffectBuilderOptionOne[C](handler)
+  }
 }

--- a/src/main/scala/com/lightbend/lagom/core/persistence/effects/core/persistence/PersistentEntity.scala
+++ b/src/main/scala/com/lightbend/lagom/core/persistence/effects/core/persistence/PersistentEntity.scala
@@ -5,6 +5,7 @@ import com.sun.net.httpserver.Authenticator.Failure
 
 import scala.collection.immutable
 import scala.concurrent.Future
+import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util.{Failure, Try}
 
@@ -27,9 +28,9 @@ object PersistentEntity {
 
 abstract class PersistentEntity[Command <: WithReply, Event, State] {
 
-  type Behavior = PartialFunction[Option[State], Actions]
+  type Behavior = PartialFunction[Option[State], Handlers]
 
-  type StateToActions = PartialFunction[State, Actions]
+  type StateToHandlers = PartialFunction[State, Handlers]
 
   type CommandToEffect = PartialFunction[Command, Effect[Command]]
   type CommandHandler = PartialFunction[Command, Try[immutable.Seq[Event]]]
@@ -49,11 +50,11 @@ abstract class PersistentEntity[Command <: WithReply, Event, State] {
       *
       * Based on the observation that () => Actions can be lifted to None => Actions (see bellow)
       */
-    def first(creationActions: => Actions) =
+    def first(creationActions: => Handlers) =
       new BehaviorBuilderAndThen(creationActions)
   }
 
-  class BehaviorBuilderAndThen(creationActions: => Actions) {
+  class BehaviorBuilderAndThen(creationActions: => Handlers) {
 
     /**
       * Adds entity actions for post-construction phase.
@@ -62,7 +63,7 @@ abstract class PersistentEntity[Command <: WithReply, Event, State] {
       *
       * Based on the observation that State => Actions can be lifted to Some[State] => Actions (see bellow)
       */
-    def andThen(updateActions: StateToActions): Behavior = { // <- Behavior == PartialFunction[Option[State], Actions]
+    def andThen(updateActions: StateToHandlers): Behavior = { // <- Behavior == PartialFunction[Option[State], Actions]
 
       // when None, we need to create it
       case None => creationActions
@@ -75,30 +76,76 @@ abstract class PersistentEntity[Command <: WithReply, Event, State] {
 
   def Behavior = BehaviorBuilderFirst
 
-  case class Actions(commandHandlers: CommandToEffect, eventHandlers: EventHandler) {
+  sealed trait HandlersT
 
-    def onCommand[C <: Command](effect: Effect[C]): Actions = {
+  final case class Handlers(commandHandlers: CommandToEffect = PartialFunction.empty,
+                            eventHandlers: EventHandler = PartialFunction.empty) extends HandlersT {
+
+    def and(handlers: HandlersT) = {
+
+      handlers match {
+        case cmd: CommandHandlers =>
+          copy(commandHandlers = this.commandHandlers.orElse(cmd.commandHandlers))
+        case evt: EventHandlers =>
+          copy(eventHandlers = this.eventHandlers.orElse(evt.eventHandlers))
+        case comb: Handlers =>
+          copy(
+            commandHandlers = this.commandHandlers.orElse(comb.commandHandlers),
+            eventHandlers = this.eventHandlers.orElse(comb.eventHandlers)
+          )
+      }
+    }
+  }
+
+  def onCommand[C <: Command](effect: Effect[C]): CommandHandlers = CommandHandlers(effect.toCommandHandler)
+
+  case class CommandHandlers(commandHandlers: CommandToEffect) extends HandlersT {
+    def onCommand[C <: Command](effect: Effect[C]): CommandHandlers =
       copy(commandHandlers = commandHandlers.orElse(effect.toCommandHandler))
+
+    def and(handlers: HandlersT): Handlers = {
+
+      handlers match {
+        case cmd: CommandHandlers =>
+          Handlers(commandHandlers = this.commandHandlers.orElse(cmd.commandHandlers))
+
+        case evt: EventHandlers =>
+          Handlers(
+            commandHandlers = this.commandHandlers,
+            eventHandlers = evt.eventHandlers
+          )
+
+        case comb: Handlers =>
+          comb.copy(commandHandlers = this.commandHandlers.orElse(comb.commandHandlers))
+      }
     }
 
-    def onEvent(eventHandler: EventHandler) = {
+  }
+
+  def onEvent(eventHandler: EventHandler): EventHandlers = EventHandlers(eventHandler)
+
+  case class EventHandlers(eventHandlers: EventHandler) extends HandlersT {
+
+    def onEvent(eventHandler: EventHandler): EventHandlers =
       copy(eventHandlers = eventHandlers.orElse(eventHandler))
-    }
 
-    def orElse(a: Actions) = {
-      copy(
-        commandHandlers = this.commandHandlers.orElse(a.commandHandlers),
-        eventHandlers = this.eventHandlers.orElse(a.eventHandlers)
-      )
+    def and(handlers: HandlersT): Handlers = {
+
+      handlers match {
+        case cmd: CommandHandlers =>
+          Handlers(
+            commandHandlers = cmd.commandHandlers,
+            eventHandlers = this.eventHandlers
+          )
+
+        case evt: EventHandlers =>
+          Handlers(eventHandlers = this.eventHandlers.orElse(evt.eventHandlers))
+
+        case comb: Handlers =>
+          comb.copy(eventHandlers = this.eventHandlers.orElse(comb.eventHandlers))
+      }
     }
   }
-
-
-  object Actions {
-    def apply(): Actions = Actions(commandHandlers = PartialFunction.empty, eventHandlers = PartialFunction.empty)
-  }
-
-  def actions = Actions()
 
   case class Effect[C <: WithReply](
                                      handler: PartialFunction[Command, Try[immutable.Seq[Event]]],
@@ -128,7 +175,7 @@ abstract class PersistentEntity[Command <: WithReply, Event, State] {
 
       // NoOps handler won't ever emit events
       val noOpsHandler: PartialFunction[C, Try[immutable.Seq[Event]]] = {
-        case cmd => Try(immutable.Seq.empty)
+        case _ => Try(immutable.Seq.empty)
       }
 
       EffectBuilderAll(noOpsHandler).replyWith(reply)
@@ -171,11 +218,11 @@ abstract class PersistentEntity[Command <: WithReply, Event, State] {
       // lift handler from Option[Event] to Seq[Event]
       val liftedHandler: PartialFunction[C, Try[immutable.Seq[Event]]] = {
         case cmd if handler.isDefinedAt(cmd) =>
-            Try {
-              handler(cmd) // from Option to Seq
-                .map(e => immutable.Seq(e))
-                .getOrElse(immutable.Seq.empty)
-            }
+          Try {
+            handler(cmd) // from Option to Seq
+              .map(e => immutable.Seq(e))
+              .getOrElse(immutable.Seq.empty)
+          }
       }
 
       // lift callbacks from Option[Event] to Seq[Event]
@@ -205,7 +252,7 @@ abstract class PersistentEntity[Command <: WithReply, Event, State] {
       val handlerCmd: CommandHandler = {
         case cmd
           if target.runtimeClass == cmd.getClass &&
-             handler.isDefinedAt(cmd.asInstanceOf[C]) => handler(cmd.asInstanceOf[C])
+            handler.isDefinedAt(cmd.asInstanceOf[C]) => handler(cmd.asInstanceOf[C])
       }
 
       Effect(
@@ -215,8 +262,6 @@ abstract class PersistentEntity[Command <: WithReply, Event, State] {
       )
     }
   }
-
-
 
 
   object ReadOnly {
@@ -253,11 +298,8 @@ abstract class PersistentEntity[Command <: WithReply, Event, State] {
     }
 
     object optionally {
-      def persistOne(handler: PartialFunction[C, Option[Event]]): EffectBuilderAll[C] =
-        EffectBuilderAll[C] {
-          // lifted PartialFunction
-          case cmd if handler.isDefinedAt(cmd) => Try(handler(cmd).toList)
-        }
+      def persistOne(handler: PartialFunction[C, Option[Event]]): EffectBuilderOptionOne[C] =
+        EffectBuilderOptionOne[C](handler)
     }
 
   }


### PR DESCRIPTION
This is another experiment. It uses `Handlers` instead of `Actions`. 

The API kind of force us to define them apart and then combine them all to  build the final `Handlers`.


